### PR TITLE
fix: Specify React version as 17

### DIFF
--- a/create-app.ts
+++ b/create-app.ts
@@ -94,7 +94,7 @@ export async function createApp({
   /**
    * Default dependencies.
    */
-  const dependencies = ['react', 'react-dom', 'next', 'wagmi', 'ethers'];
+  const dependencies = ['react@17.0.0', 'react-dom@17.0.0', 'next', 'wagmi', 'ethers'];
   /**
    * Default devDependencies.
    */


### PR DESCRIPTION
Since `wagmi` is not compatible with React 18 yet, we need to explicitly specify our React version as 17 in order for everything to work. 

Closes #5 